### PR TITLE
Agrega prueba fallando del generador de índices

### DIFF
--- a/mean_differences_mc/Tester_Significant_Difference.py
+++ b/mean_differences_mc/Tester_Significant_Difference.py
@@ -1,4 +1,5 @@
 from .switch_elements import *
+from .index_switch import index_to_switch
 
 class Tester_Significant_Difference:
     def __init__(self):
@@ -25,3 +26,7 @@ class Tester_Significant_Difference:
 
     def switch_elements(self, index):
         self.sample_a, self.sample_b = switch_elements_arrays(self.sample_a, self.sample_b, index)
+
+    def index_to_switch(self):
+        lim_max = len(self.sample_a)
+        return(index_to_switch(lim_max))

--- a/tests/test_Tester_Significant_Difference.py
+++ b/tests/test_Tester_Significant_Difference.py
@@ -3,6 +3,7 @@ import datetime
 import pandas as pd
 import numpy as np
 from mean_differences_mc import *
+from random import seed
 
 
 class TestTesterSignificantDifference(unittest.TestCase):
@@ -18,6 +19,8 @@ class TestTesterSignificantDifference(unittest.TestCase):
         self.sample_a_final: np.array = np.array([1., 8., 3., 4.])
         self.sample_b_final: np.array = np.array([5., 6., 7., 2.])
         self.Probador_Diferencias_Significativas: Tester_Significant_Difference = Tester_Significant_Difference()
+        self.testing_index: list = [1, 0, 2, 0, 15, 24]
+        seed(1)
 
     def test_initialization(self):
         """
@@ -53,6 +56,15 @@ class TestTesterSignificantDifference(unittest.TestCase):
         self.assertTrue((self.sample_a_final == muestra_a).all())
         muestra_b: np.array = self.Probador_Diferencias_Significativas.sample_b
         self.assertTrue((self.sample_b_final == muestra_b).all())
+
+    def test_index_to_switch(self):
+        """
+        Verifica que la función `index_to_switch` genere dos indices correctos
+        """
+        sample_a: pd.DataFrame = pd.DataFrame({"sample_a": range(3)})
+        self.Probador_Diferencias_Significativas.sample_a = sample_a
+        index = self.Probador_Diferencias_Significativas.index_to_switch()
+        self.assertEqual(self.testing_index[0:2], index)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_Tester_Significant_Difference.py
+++ b/tests/test_Tester_Significant_Difference.py
@@ -65,6 +65,12 @@ class TestTesterSignificantDifference(unittest.TestCase):
         self.Probador_Diferencias_Significativas.sample_a = sample_a
         index = self.Probador_Diferencias_Significativas.index_to_switch()
         self.assertEqual(self.testing_index[0:2], index)
+        index = self.Probador_Diferencias_Significativas.index_to_switch()
+        self.assertEqual(self.testing_index[2:4], index)
+        sample_a: pd.DataFrame = pd.DataFrame({"sample_a": range(30)})
+        self.Probador_Diferencias_Significativas.sample_a = sample_a
+        index = self.Probador_Diferencias_Significativas.index_to_switch()
+        self.assertEqual(self.testing_index[4:6], index)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Implementa el método `index_to_switch`. Ya existe la función similar con sus respectivas pruebas. Lo que hará el método es generar índices de los elementos que intercambiará de las dos muestras. Así que los índices permitidos dependen del tamaño de las muestras